### PR TITLE
Fix market bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,19 @@
 # Compound-V2-subgraph
-[Compound](https://compound.finance/) is an open-source protocol for algorithmic, efficient Money Markets on the Ethereum blockchain. This Subgraph ingests the V2 contracts of the protocol. See [here](https://github.com/graphprotocol/compound-subgraph) for the V1 subgraph.
+
+[Compound](https://compound.finance/) is an open-source protocol for algorithmic, efficient Money Markets on the Ethereum blockchain. This Subgraph ingests the V2 contracts of the protocol.
 
 ## Networks and Performance
 
-This subgraph can be found on The Graph Hosted Service at https://thegraph.com/explorer/subgraph/compound-finance/compound.
+This subgraph can be found on The Graph Hosted Service at https://thegraph.com/explorer/subgraph/graphprotocol/compound-v2.
 
 You can also run this subgraph locally, if you wish. Instructions for that can be found in [The Graph Documentation](https://thegraph.com/docs/quick-start).
 
-## Contract Upgrades
-
-The subgraph will be kept in sync with the development of Compound-V2 until the official mainnet launch. The Hosted service will always be updated with the most recent subgraph.
-
-After that, the only changes to V2 should be new assets added, which the subgraph will stay up to date with. This may be possible to do so dynamically, without subgraph updates. To be concluded.
-
-### Contracts not tracked at all
-
-These contracts were left out:
-
-- `PriceOracle.sol` - For the testnet this is just a simple price oracle, it will be updated to a real one on mainnet, and likely included in the subgraph
-- `StableCoinInterestRateModel.sol` - No data was chosen to be sourced from here
-- `StandardInterestRateModel.sol` - No data was chosen to be sourced from here
-
 ### ABI
 
-The ABI used is `ctoken.json`. It is a stripped down version of the full abi provided by compound, that satisfies the calls we need to make for both cETH and cERC20 contracts. This way we can use 1 ABI file, and one mapping for cETH and cERC20. 
+The ABI used is `ctoken.json`. It is a stripped down version of the full abi provided by compound, that satisfies the calls we need to make for both cETH and cERC20 contracts. This way we can use 1 ABI file, and one mapping for cETH and cERC20.
 
 ## Getting started with querying
+
 Below are a few ways to show how to query the Compound V2 Subgraph for data. The queries show most of the information that is queryable, but there are many other filtering options that can be used, just check out the [querying api](https://github.com/graphprotocol/graph-node/blob/master/docs/graphql-api.md).
 
-### Querying All Markets
-```graphql
-{
-  markets{
-    id
-    symbol
-    accrualBlockNumber
-    totalSupply
-    exchangeRate
-    totalReserves
-    totalCash
-    totalDeposits
-    totalBorrows
-    perBlockBorrowInterest
-    perBlockSupplyInterest
-    borrowIndex
-    tokenPerEthRatio
-    tokenPerUSDRatio
-  }
-}
-```
-
-### Querying All Users, and all their CToken balances
-Commented out values are temporarily not being used.
-```graphql
-{
-  users{
-    id
-    countLiquidated
-    countLiquidator
-#    accountLiquidity
-#    availableToBorrowEth
-#    totalSupplyInEth
-#    totalBorrowInEth
-    cTokens{
-      id
-      user
-      accrualBlockNumber
-      transactionTimes
-      transactionHashes
-      cTokenBalance
-      underlyingSupplied
-      underlyingRedeemed
-#      underlyingBalance
-#      interestEarned
-      totalBorrowed
-      totalRepaid
-#      borrowBalance
-#      borrowInterest
-    }
-  }
-}
-```
+You can also see the saved queries on the hosted service for examples.

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "prettier": "./node_modules/.bin/prettier —-write '**/*.ts'"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "http://github.com/graphprotocol/graph-cli#ford/add-startblock-to-contract-source",
-    "@graphprotocol/graph-ts": "^0.15.1",
+    "@graphprotocol/graph-cli": "0.16.0",
+    "@graphprotocol/graph-ts": "0.16.0",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "eslint": "^6.2.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prettier": "./node_modules/.bin/prettier —-write '**/*.ts'"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "0.16.0",
+    "@graphprotocol/graph-cli": "0.16.1",
     "@graphprotocol/graph-ts": "0.16.0",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "graph build",
     "create-local": "graph create compound-finance/compound-v2 --node http://127.0.0.1:8020",
     "deploy-local": "graph deploy compound-finance/compound-v2 --debug --ipfs http://localhost:5001 --node http://127.0.0.1:8020/",
-    "deploy": "graph deploy compound-finance/compound-v2 --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
+    "deploy": "graph deploy graphprotocol/compound-v2 --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "prodtest": "graph deploy davekaj/compound-v2 --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "deploy-staging": "graph deploy --debug --ipfs https://api.staging.thegraph.com/ipfs/ --node https://api.staging.thegraph.com/deploy/ davekaj/compoundv2",
     "watch-local": "graph deploy compound-finance/compound-v2 --watch --debug --node http://127.0.0.1:8020/ --ipfs http://localhost:5001",

--- a/package.json
+++ b/package.json
@@ -6,12 +6,10 @@
   "scripts": {
     "codegen": "graph codegen --output-dir src/types/",
     "build": "graph build",
-    "create-local": "graph create compound-finance/compound-v2 --node http://127.0.0.1:8020",
-    "deploy-local": "graph deploy compound-finance/compound-v2 --debug --ipfs http://localhost:5001 --node http://127.0.0.1:8020/",
+    "create-local": "graph create graphprotocol/compound-v2 --node http://127.0.0.1:8020",
+    "deploy-local": "graph deploy graphprotocol/compound-v2 --debug --ipfs http://localhost:5001 --node http://127.0.0.1:8020/",
     "deploy": "graph deploy graphprotocol/compound-v2 --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
-    "prodtest": "graph deploy davekaj/compound-v2 --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "deploy-staging": "graph deploy --debug --ipfs https://api.staging.thegraph.com/ipfs/ --node https://api.staging.thegraph.com/deploy/ davekaj/compoundv2",
-    "watch-local": "graph deploy compound-finance/compound-v2 --watch --debug --node http://127.0.0.1:8020/ --ipfs http://localhost:5001",
     "prettier": "./node_modules/.bin/prettier —-write '**/*.ts'"
   },
   "devDependencies": {

--- a/schema.graphql
+++ b/schema.graphql
@@ -27,10 +27,10 @@ type Market @entity { # TODO rename to CToken, not market AND ALL OTHERS
     interestRateModelAddress: Bytes!
     "Name of the cToken"
     name: String!
-    # "Number of borrowers active in the market"
-    # numberOfBorrowers: Int!
-    # "Number of suppliers active in the market"
-    # numberOfSuppliers: Int!
+    "Number of borrowers active in the market"
+    numberOfBorrowers: Int!
+    "Number of suppliers active in the market"
+    numberOfSuppliers: Int!
     "Reserves stored in the contract"
     reserves: BigDecimal!
     "Yearly supply rate. With 2104400 blocks per year"

--- a/schema.graphql
+++ b/schema.graphql
@@ -27,10 +27,10 @@ type Market @entity { # TODO rename to CToken, not market AND ALL OTHERS
     interestRateModelAddress: Bytes!
     "Name of the cToken"
     name: String!
-    "Number of borrowers active in the market"
-    numberOfBorrowers: Int!
-    "Number of suppliers active in the market"
-    numberOfSuppliers: Int!
+    # "Number of borrowers active in the market"
+    # numberOfBorrowers: Int!
+    # "Number of suppliers active in the market"
+    # numberOfSuppliers: Int!
     "Reserves stored in the contract"
     reserves: BigDecimal!
     "Yearly supply rate. With 2104400 blocks per year"

--- a/schema.graphql
+++ b/schema.graphql
@@ -27,10 +27,6 @@ type Market @entity { # TODO rename to CToken, not market AND ALL OTHERS
     interestRateModelAddress: Bytes!
     "Name of the cToken"
     name: String!
-    "Number of borrowers active in the market"
-    numberOfBorrowers: Int!
-    "Number of suppliers active in the market"
-    numberOfSuppliers: Int!
     "Reserves stored in the contract"
     reserves: BigDecimal!
     "Yearly supply rate. With 2104400 blocks per year"

--- a/src/mappings/comptroller.ts
+++ b/src/mappings/comptroller.ts
@@ -10,12 +10,17 @@ import {
   NewPriceOracle,
 } from '../types/comptroller/Comptroller'
 
-import { Market, Comptroller } from '../types/schema'
-import { mantissaFactorBD, updateCommonCTokenStats } from './helpers'
+import { Market, Comptroller, Account } from '../types/schema'
+import { mantissaFactorBD, updateCommonCTokenStats, createAccount } from './helpers'
 
 export function handleMarketEntered(event: MarketEntered): void {
   let market = Market.load(event.params.cToken.toHexString())
   let accountID = event.params.account.toHex()
+  let account = Account.load(accountID)
+  if (account == null) {
+    createAccount(accountID)
+  }
+
   let cTokenStats = updateCommonCTokenStats(
     market.id,
     market.symbol,
@@ -31,6 +36,11 @@ export function handleMarketEntered(event: MarketEntered): void {
 export function handleMarketExited(event: MarketExited): void {
   let market = Market.load(event.params.cToken.toHexString())
   let accountID = event.params.account.toHex()
+  let account = Account.load(accountID)
+  if (account == null) {
+    createAccount(accountID)
+  }
+
   let cTokenStats = updateCommonCTokenStats(
     market.id,
     market.symbol,

--- a/src/mappings/ctoken.ts
+++ b/src/mappings/ctoken.ts
@@ -19,6 +19,7 @@ import {
   exponentToBigDecimal,
   cTokenDecimalsBD,
   cTokenDecimals,
+  zeroBD,
 } from './helpers'
 
 /* Account supplies assets into market and receives cTokens in exchange

--- a/src/mappings/ctoken.ts
+++ b/src/mappings/ctoken.ts
@@ -89,7 +89,7 @@ export function handleBorrow(event: Borrow): void {
   let borrowAmountBD = event.params.borrowAmount
     .toBigDecimal()
     .div(exponentToBigDecimal(market.underlyingDecimals))
-  // let previousBorrow = cTokenStats.storedBorrowBalance
+  let previousBorrow = cTokenStats.storedBorrowBalance
 
   cTokenStats.storedBorrowBalance = event.params.accountBorrows
     .toBigDecimal()
@@ -102,13 +102,13 @@ export function handleBorrow(event: Borrow): void {
   )
   cTokenStats.save()
 
-  // if (
-  //   previousBorrow.equals(zeroBD) &&
-  //   !event.params.accountBorrows.toBigDecimal().equals(zeroBD) // checking edge case for borrwing 0
-  // ) {
-  //   market.numberOfBorrowers = market.numberOfBorrowers + 1
-  //   market.save()
-  // }
+  if (
+    previousBorrow.equals(zeroBD) &&
+    !event.params.accountBorrows.toBigDecimal().equals(zeroBD) // checking edge case for borrwing 0
+  ) {
+    market.numberOfBorrowers = market.numberOfBorrowers + 1
+    market.save()
+  }
 }
 
 /* Repay some amount borrowed. Anyone can repay anyones balance
@@ -159,10 +159,10 @@ export function handleRepayBorrow(event: RepayBorrow): void {
   )
   cTokenStats.save()
 
-  // if (cTokenStats.storedBorrowBalance.equals(zeroBD)) {
-  //   market.numberOfBorrowers = market.numberOfBorrowers - 1
-  //   market.save()
-  // }
+  if (cTokenStats.storedBorrowBalance.equals(zeroBD)) {
+    market.numberOfBorrowers = market.numberOfBorrowers - 1
+    market.save()
+  }
 }
 
 /*
@@ -264,10 +264,10 @@ export function handleTransfer(event: Transfer): void {
     )
     cTokenStatsFrom.save()
 
-    // if (cTokenStatsFrom.cTokenBalance.equals(zeroBD)) {
-    //   market.numberOfSuppliers = market.numberOfSuppliers - 1
-    //   market.save()
-    // }
+    if (cTokenStatsFrom.cTokenBalance.equals(zeroBD)) {
+      market.numberOfSuppliers = market.numberOfSuppliers - 1
+      market.save()
+    }
   }
 
   // Checking if the tx is TO the cToken contract (i.e. this will not run when redeeming)
@@ -305,13 +305,13 @@ export function handleTransfer(event: Transfer): void {
     )
     cTokenStatsTo.save()
 
-    // if (
-    //   previousCTokenBalanceTo.equals(zeroBD) &&
-    //   !event.params.amount.toBigDecimal().equals(zeroBD) // checking edge case for transfers of 0
-    // ) {
-    //   market.numberOfSuppliers = market.numberOfSuppliers + 1
-    //   market.save()
-    // }
+    if (
+      previousCTokenBalanceTo.equals(zeroBD) &&
+      !event.params.amount.toBigDecimal().equals(zeroBD) // checking edge case for transfers of 0
+    ) {
+      market.numberOfSuppliers = market.numberOfSuppliers + 1
+      market.save()
+    }
   }
 }
 

--- a/src/mappings/ctoken.ts
+++ b/src/mappings/ctoken.ts
@@ -105,13 +105,13 @@ export function handleBorrow(event: Borrow): void {
   account.hasBorrowed = true
   account.save()
 
-  if (
-    previousBorrow.equals(zeroBD) &&
-    !event.params.accountBorrows.toBigDecimal().equals(zeroBD) // checking edge case for borrwing 0
-  ) {
-    market.numberOfBorrowers = market.numberOfBorrowers + 1
-    market.save()
-  }
+  // if (
+  //   previousBorrow.equals(zeroBD) &&
+  //   !event.params.accountBorrows.toBigDecimal().equals(zeroBD) // checking edge case for borrwing 0
+  // ) {
+  //   market.numberOfBorrowers = market.numberOfBorrowers + 1
+  //   market.save()
+  // }
 }
 
 /* Repay some amount borrowed. Anyone can repay anyones balance
@@ -163,10 +163,10 @@ export function handleRepayBorrow(event: RepayBorrow): void {
     createAccount(accountID)
   }
 
-  if (cTokenStats.storedBorrowBalance.equals(zeroBD)) {
-    market.numberOfBorrowers = market.numberOfBorrowers - 1
-    market.save()
-  }
+  // if (cTokenStats.storedBorrowBalance.equals(zeroBD)) {
+  //   market.numberOfBorrowers = market.numberOfBorrowers - 1
+  //   market.save()
+  // }
 }
 
 /*
@@ -269,10 +269,10 @@ export function handleTransfer(event: Transfer): void {
     )
     cTokenStatsFrom.save()
 
-    if (cTokenStatsFrom.cTokenBalance.equals(zeroBD)) {
-      market.numberOfSuppliers = market.numberOfSuppliers - 1
-      market.save()
-    }
+    // if (cTokenStatsFrom.cTokenBalance.equals(zeroBD)) {
+    //   market.numberOfSuppliers = market.numberOfSuppliers - 1
+    //   market.save()
+    // }
   }
 
   let accountToID = event.params.to.toHex()
@@ -310,13 +310,13 @@ export function handleTransfer(event: Transfer): void {
     )
     cTokenStatsTo.save()
 
-    if (
-      previousCTokenBalanceTo.equals(zeroBD) &&
-      !event.params.amount.toBigDecimal().equals(zeroBD) // checking edge case for transfers of 0
-    ) {
-      market.numberOfSuppliers = market.numberOfSuppliers + 1
-      market.save()
-    }
+    // if (
+    //   previousCTokenBalanceTo.equals(zeroBD) &&
+    //   !event.params.amount.toBigDecimal().equals(zeroBD) // checking edge case for transfers of 0
+    // ) {
+    //   market.numberOfSuppliers = market.numberOfSuppliers + 1
+    //   market.save()
+    // }
   }
 }
 

--- a/src/mappings/ctoken.ts
+++ b/src/mappings/ctoken.ts
@@ -102,14 +102,6 @@ export function handleBorrow(event: Borrow): void {
     borrowAmountBD,
   )
   cTokenStats.save()
-
-  if (
-    previousBorrow.equals(zeroBD) &&
-    !event.params.accountBorrows.toBigDecimal().equals(zeroBD) // checking edge case for borrwing 0
-  ) {
-    market.numberOfBorrowers = market.numberOfBorrowers + 1
-    market.save()
-  }
 }
 
 /* Repay some amount borrowed. Anyone can repay anyones balance
@@ -159,11 +151,6 @@ export function handleRepayBorrow(event: RepayBorrow): void {
     repayAmountBD,
   )
   cTokenStats.save()
-
-  if (cTokenStats.storedBorrowBalance.equals(zeroBD)) {
-    market.numberOfBorrowers = market.numberOfBorrowers - 1
-    market.save()
-  }
 }
 
 /*
@@ -264,11 +251,6 @@ export function handleTransfer(event: Transfer): void {
       amountUnderylingTruncated,
     )
     cTokenStatsFrom.save()
-
-    if (cTokenStatsFrom.cTokenBalance.equals(zeroBD)) {
-      market.numberOfSuppliers = market.numberOfSuppliers - 1
-      market.save()
-    }
   }
 
   // Checking if the tx is TO the cToken contract (i.e. this will not run when redeeming)
@@ -305,14 +287,6 @@ export function handleTransfer(event: Transfer): void {
       amountUnderylingTruncated,
     )
     cTokenStatsTo.save()
-
-    if (
-      previousCTokenBalanceTo.equals(zeroBD) &&
-      !event.params.amount.toBigDecimal().equals(zeroBD) // checking edge case for transfers of 0
-    ) {
-      market.numberOfSuppliers = market.numberOfSuppliers + 1
-      market.save()
-    }
   }
 }
 

--- a/src/mappings/markets.ts
+++ b/src/mappings/markets.ts
@@ -144,8 +144,8 @@ export function createMarket(marketAddress: string): Market {
     '0x0000000000000000000000000000000000000000',
   )
   market.name = contract.name()
-  market.numberOfBorrowers = 0
-  market.numberOfSuppliers = 0
+  // market.numberOfBorrowers = 0
+  // market.numberOfSuppliers = 0
   market.reserves = zeroBD
   market.supplyRate = zeroBD
   market.symbol = contract.symbol()
@@ -247,7 +247,7 @@ export function updateMarket(
       .truncate(market.underlyingDecimals)
 
     // Must convert to BigDecimal, and remove 10^18 that is used for Exp in Compound Solidity
-    market.supplyRate = contract
+    market.borrowRate = contract
       .borrowRatePerBlock()
       .toBigDecimal()
       .times(BigDecimal.fromString('2102400'))
@@ -259,9 +259,9 @@ export function updateMarket(
     let supplyRatePerBlock = contract.try_supplyRatePerBlock()
     if (supplyRatePerBlock.reverted) {
       log.info('***CALL FAILED*** : cERC20 supplyRatePerBlock() reverted', [])
-      market.borrowRate = zeroBD
+      market.supplyRate = zeroBD
     } else {
-      market.borrowRate = supplyRatePerBlock.value
+      market.supplyRate = supplyRatePerBlock.value
         .toBigDecimal()
         .times(BigDecimal.fromString('2102400'))
         .div(mantissaFactorBD)

--- a/src/mappings/markets.ts
+++ b/src/mappings/markets.ts
@@ -144,8 +144,8 @@ export function createMarket(marketAddress: string): Market {
     '0x0000000000000000000000000000000000000000',
   )
   market.name = contract.name()
-  // market.numberOfBorrowers = 0
-  // market.numberOfSuppliers = 0
+  market.numberOfBorrowers = 0
+  market.numberOfSuppliers = 0
   market.reserves = zeroBD
   market.supplyRate = zeroBD
   market.symbol = contract.symbol()

--- a/src/mappings/markets.ts
+++ b/src/mappings/markets.ts
@@ -144,8 +144,6 @@ export function createMarket(marketAddress: string): Market {
     '0x0000000000000000000000000000000000000000',
   )
   market.name = contract.name()
-  market.numberOfBorrowers = 0
-  market.numberOfSuppliers = 0
   market.reserves = zeroBD
   market.supplyRate = zeroBD
   market.symbol = contract.symbol()

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,9 +25,10 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@graphprotocol/graph-cli@http://github.com/graphprotocol/graph-cli#ford/add-startblock-to-contract-source":
-  version "0.15.1"
-  resolved "http://github.com/graphprotocol/graph-cli#1d1a6d1b8e63a62b9903191d6244033106ed1eee"
+"@graphprotocol/graph-cli@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.16.0.tgz#0829a42a2ec4c122fbdb8bfb482b74e0d27db935"
+  integrity sha512-tTpJc9waeRPzhF/aeWxu4jGW7GonVTQBeubTGVC6B2oFHpADXrQdthPgpmtThexXGHk46q14bHLuiSEm6ZBpkw==
   dependencies:
     assemblyscript "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
     chalk "^2.4.1"
@@ -49,10 +50,10 @@
   optionalDependencies:
     keytar "^4.6.0"
 
-"@graphprotocol/graph-ts@^0.15.1":
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.15.1.tgz#d6cc85197e45dda9bb4083654c183470ff23333e"
-  integrity sha512-l5veH44ULpKq1kLudbfJctgxLaLpnLnYiDIIZn+N8UC1SrpqjLhJyRMfm+uH4xTglmAwI74wyynKWktXp44/iw==
+"@graphprotocol/graph-ts@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.16.0.tgz#a6f5e8a39b7d651887c80bb2422cfb3a0fbf55d7"
+  integrity sha512-zDhlIYlzE0xq5cJkF6fGwshfPR2z6rRZetNCgEclAtDv1uPSQaPQJuiIWL2hpTMjYHLX2OSNxy8F1G69jC708A==
   dependencies:
     assemblyscript "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
 
@@ -335,9 +336,9 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
-"assemblyscript@https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3":
+"assemblyscript@git+https://github.com/AssemblyScript/assemblyscript.git#36040d5b5312f19a025782b5e36663823494c2f3":
   version "0.6.0"
-  resolved "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
+  resolved "git+https://github.com/AssemblyScript/assemblyscript.git#36040d5b5312f19a025782b5e36663823494c2f3"
   dependencies:
     "@protobufjs/utf8" "^1.1.0"
     binaryen "77.0.0-nightly.20190407"
@@ -862,10 +863,10 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-debug@^3.2.6:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
-  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
     ms "2.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,10 +25,10 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@graphprotocol/graph-cli@0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.16.0.tgz#0829a42a2ec4c122fbdb8bfb482b74e0d27db935"
-  integrity sha512-tTpJc9waeRPzhF/aeWxu4jGW7GonVTQBeubTGVC6B2oFHpADXrQdthPgpmtThexXGHk46q14bHLuiSEm6ZBpkw==
+"@graphprotocol/graph-cli@0.16.1":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.16.1.tgz#b6abaac2ffb1ea2895710db38fa9afcd40227cbc"
+  integrity sha512-NCpvjLyZGB1ugaNtcjziOAzaJ6TJlOftKPPL6sBMhIo9gXHE2qoEpvOKFQzSKOOLmD3Na8VTApbsySnYhN3MEg==
   dependencies:
     assemblyscript "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
     chalk "^2.4.1"
@@ -339,6 +339,18 @@ asn1@~0.2.3:
 "assemblyscript@git+https://github.com/AssemblyScript/assemblyscript.git#36040d5b5312f19a025782b5e36663823494c2f3":
   version "0.6.0"
   resolved "git+https://github.com/AssemblyScript/assemblyscript.git#36040d5b5312f19a025782b5e36663823494c2f3"
+  dependencies:
+    "@protobufjs/utf8" "^1.1.0"
+    binaryen "77.0.0-nightly.20190407"
+    glob "^7.1.3"
+    long "^4.0.0"
+    opencollective-postinstall "^2.0.0"
+    source-map-support "^0.5.11"
+
+"assemblyscript@https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3":
+  version "0.6.0"
+  uid "36040d5b5312f19a025782b5e36663823494c2f3"
+  resolved "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
   dependencies:
     "@protobufjs/utf8" "^1.1.0"
     binaryen "77.0.0-nightly.20190407"


### PR DESCRIPTION
Bugs fixed:
- borrow and supply rate were reversed
- npm packages were old
- accounts were not being created for entering and exiting markets
- supplier and borrower count removed because it wasn't worked. and if people really want, they could count the length of the array of all cTokens with a balance greater than 0