### PR TITLE
Refactor transaction data for AccountCToken entity

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -108,12 +108,10 @@ type AccountCToken @entity {
     symbol: String!
     "Relation to user"
     account: Account!
-    "Hashes of all user transactions"
-    transactionHashes: [Bytes!]!
-    "Times of all user transactions"
-    transactionTimes: [Int!]!
+    "Transactions data"
+    transactions: [AccountCTokenTransaction!]! @derivedFrom(field:"account")
     "Block number this asset was updated at in the contract"
-    accrualBlockNumber: Int!
+    accrualBlockNumber: BigInt!
     "True if user is entered, false if they are exited"
     enteredMarket: Boolean!
 
@@ -147,6 +145,23 @@ type AccountCToken @entity {
 
     # lifetimeBorrowInterestAccrued: BigDecimal!
     # FORMULA: lifetimeBorrowInterestAccrued = borrowBalanceUnderlying - totalUnderlyingBorrowed + totalUnderlyingRepaid
+}
+
+"""
+Auxiliary entity for AccountCToken
+"""
+type AccountCTokenTransaction @entity {
+  id: ID!
+
+  account: AccountCToken!
+
+  tx_hash: Bytes!
+
+  timestamp: BigInt!
+
+  block: BigInt!
+
+  logIndex: BigInt!
 }
 
 """

--- a/src/mappings/comptroller.ts
+++ b/src/mappings/comptroller.ts
@@ -41,8 +41,9 @@ export function handleMarketEntered(event: MarketEntered): void {
       market.symbol,
       accountID,
       event.transaction.hash,
-      event.block.timestamp.toI32(),
-      event.block.number.toI32(),
+      event.block.timestamp,
+      event.block.number,
+      event.logIndex,
     )
     cTokenStats.enteredMarket = true
     cTokenStats.save()
@@ -66,8 +67,9 @@ export function handleMarketExited(event: MarketExited): void {
       market.symbol,
       accountID,
       event.transaction.hash,
-      event.block.timestamp.toI32(),
-      event.block.number.toI32(),
+      event.block.timestamp,
+      event.block.number,
+      event.logIndex,
     )
     cTokenStats.enteredMarket = false
     cTokenStats.save()

--- a/src/mappings/ctoken.ts
+++ b/src/mappings/ctoken.ts
@@ -135,8 +135,9 @@ export function handleBorrow(event: Borrow): void {
     market.symbol,
     accountID,
     event.transaction.hash,
-    event.block.timestamp.toI32(),
-    event.block.number.toI32(),
+    event.block.timestamp,
+    event.block.number,
+    event.logIndex,
   )
 
   let borrowAmountBD = event.params.borrowAmount
@@ -208,8 +209,9 @@ export function handleRepayBorrow(event: RepayBorrow): void {
     market.symbol,
     accountID,
     event.transaction.hash,
-    event.block.timestamp.toI32(),
-    event.block.number.toI32(),
+    event.block.timestamp,
+    event.block.number,
+    event.logIndex,
   )
 
   let repayAmountBD = event.params.repayAmount
@@ -367,8 +369,9 @@ export function handleTransfer(event: Transfer): void {
       market.symbol,
       accountFromID,
       event.transaction.hash,
-      event.block.timestamp.toI32(),
-      event.block.number.toI32(),
+      event.block.timestamp,
+      event.block.number,
+      event.logIndex,
     )
 
     cTokenStatsFrom.cTokenBalance = cTokenStatsFrom.cTokenBalance.minus(
@@ -402,8 +405,9 @@ export function handleTransfer(event: Transfer): void {
       market.symbol,
       accountToID,
       event.transaction.hash,
-      event.block.timestamp.toI32(),
-      event.block.number.toI32(),
+      event.block.timestamp,
+      event.block.number,
+      event.logIndex,
     )
 
     cTokenStatsTo.cTokenBalance = cTokenStatsTo.cTokenBalance.plus(


### PR DESCRIPTION
Refactoring `transactionHases` and `transactionTimes` arrays in hopes to improve db performance on high count arrays.
Currently indexing in https://thegraph.com/explorer/subgraph/juanmardefago/compound-v2?version=pending to check for any runtime failures.