### PR TITLE
docs: explain that the js wrapper is a custom feature

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -133,6 +133,8 @@ type AccountCToken @entity {
     # The following values are added by the JS Wrapper, and must be calculated with the most up
     # to date values based on the block delta for market.exchangeRate and market.borrowIndex
     # They do not need to be in the schema, but they will show up in the explorer playground
+    # NOTE: this a custom feature that The Graph implemented for our subgraph. It's not yet
+    # available to the public.
 
     # supplyBalanceUnderlying: BigDecimal!
     # FORMULA: supplyBalanceUnderlying = cTokenBalance * market.exchangeRate


### PR DESCRIPTION
I was confused about these fields part of the `AccountFyToken` schema:

+ supplyBalanceUnderlying
+ lifetimeSupplyInterestAccrued
+ borrowBalanceUnderlying
+ lifetimeBorrowInterestAccrued

They are queryable in the [explorer playground][1] but not defined anywhere in the source code.

I later saw this comment left by @Jannis on Discord:

<img width="980" alt="Capture d’écran 2020-11-05 à 17 18 30" src="https://user-images.githubusercontent.com/8782666/98259531-ee5dba80-1f8a-11eb-8f30-461ad384a6b4.png">

[1]: https://thegraph.com/explorer/subgraph/graphprotocol/compound-v2