### PR TITLE
Update The Graph quick start link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This subgraph can be found on The Graph Hosted Service at https://thegraph.com/explorer/subgraph/graphprotocol/compound-v2.
 
-You can also run this subgraph locally, if you wish. Instructions for that can be found in [The Graph Documentation](https://thegraph.com/docs/quick-start).
+You can also run this subgraph locally, if you wish. Instructions for that can be found in [The Graph Documentation](https://thegraph.com/docs/en/developer/quick-start/).
 
 ### ABI
 


### PR DESCRIPTION
The current quick start link leads to a 404 page